### PR TITLE
Use GitHub API to retrive the latest release.

### DIFF
--- a/FlashLightInstaller.vcxproj
+++ b/FlashLightInstaller.vcxproj
@@ -120,8 +120,9 @@
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -134,10 +135,11 @@
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/FlashLightInstaller.vcxproj
+++ b/FlashLightInstaller.vcxproj
@@ -92,7 +92,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>Shlwapi.lib;urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>urlmon.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -109,7 +109,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>Shlwapi.lib;urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>urlmon.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/FlashLightInstaller.vcxproj
+++ b/FlashLightInstaller.vcxproj
@@ -92,7 +92,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Shlwapi.lib;urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -109,7 +109,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Shlwapi.lib;urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,20 +1,52 @@
-#include <iostream>
-
 #include <Windows.h>
-
+#include <shlwapi.h>
 #include <urlmon.h>
-#include <sstream>
 
+#include <sstream>
 #include <vector>
 
-int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow)
+/// <summary>
+/// Download and parse github html to retrive the filename of the latest NorthStar release.
+/// </summary>
+/// <returns></returns>
+LPCWSTR GetDownloadURL()
 {
 	IStream* fileStream;
-	HRESULT downloadResult = URLOpenBlockingStream(NULL, L"https://github.com/R2Northstar/Northstar/releases/latest/download/Northstar.release.v1.14.2.zip", &fileStream, 0, NULL);
+	HRESULT downloadResult = URLOpenBlockingStream(NULL, L"https://github.com/R2Northstar/Northstar/releases/latest/", &fileStream, 0, NULL);
+
+	STATSTG streamStats{};
+
+	fileStream->Stat(&streamStats, STATFLAG_DEFAULT);
+
+	DWORD stringSize = streamStats.cbSize.LowPart;
+
+	std::string htmlStr;
+	htmlStr.reserve(stringSize);
+
+	DWORD byteCount;
+
+	fileStream->Read(&htmlStr[0], stringSize, &byteCount);
+	fileStream->Release();
+
+	constexpr int searchStringSize = 41; //size of -> "/R2Northstar/Northstar/releases/download/"
+	const int linkOffset = htmlStr.find("/R2Northstar/Northstar/releases/download/", 0);
+
+	//htmlStr.s
+
+	return L"";
+}
+
+/// <summary>
+/// Download and write the file at url pFileURL onto the disk.
+/// </summary>
+/// <param name="pFileURL"> : Url of the desired file.</param>
+void DownloadFile(LPCWSTR pFileURL)
+{
+	IStream* fileStream;
+	HRESULT downloadResult = URLOpenBlockingStream(NULL, pFileURL, &fileStream, 0, NULL);
 
 	if (!SUCCEEDED(downloadResult))
-		return 1;
-
+		return;
 
 	STATSTG streamStats{};
 
@@ -30,11 +62,21 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
 
 	fileStream->Release();
 
-	HANDLE zipHandle = CreateFileA("./NorthStar.zip", GENERIC_WRITE, 0, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+	//Write file
+	std::wstring fileName(pFileURL);
+	PathStripPath(&fileName[0]);
+
+	HANDLE zipHandle = CreateFileA("./Northstar.release.v1.14.2.zip", GENERIC_WRITE, 0, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
 
 	WriteFile(zipHandle, fileBuffer.data(), fileSize, &byteCount, NULL);
 
 	CloseHandle(zipHandle);
+
+}
+
+int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow)
+{
+	DownloadFile(L"https://github.com/R2Northstar/Northstar/releases/latest/download/Northstar.release.v1.14.2.zip");
 
 	return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <Windows.h>
 #include <urlmon.h>
+#include <shlwapi.h>
 
 #include <sstream>
 #include <vector>
@@ -64,11 +65,11 @@ void DownloadFile(const std::string& pFileURL)
 
 	fileStream->Release();
 	
-	//TODO :
-	//Get filename with :
-	//	PathStripPath(&wURL[0]);
+	PathStripPath(&wURL[0]);
 
-	HANDLE zipHandle = CreateFileA("./Northstar.release.v1.14.2.zip", GENERIC_WRITE, 0, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+	std::string fileName(wURL.begin(), wURL.end());
+
+	HANDLE zipHandle = CreateFileA(&fileName[0], GENERIC_WRITE, 0, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
 
 	WriteFile(zipHandle, fileBuffer.data(), fileSize, &byteCount, NULL);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,25 +19,25 @@ std::string GetDownloadURL()
 
 	DWORD stringSize = streamStats.cbSize.LowPart;
 
-	std::string htmlStr;
+	std::string resultStr;
 
-	htmlStr.reserve(stringSize);
-	htmlStr.resize(stringSize);
+	resultStr.reserve(stringSize);
+	resultStr.resize(stringSize);
 
 	DWORD byteCount;
 
-	fileStream->Read(&htmlStr[0], stringSize, &byteCount);
+	fileStream->Read(&resultStr[0], stringSize, &byteCount);
 	fileStream->Release();
 
 	constexpr int searchStrSize = 23;
-	int urlOffset	= htmlStr.find("\"browser_download_url\":") + searchStrSize;
-	int urlStrSize  = (htmlStr.find(".zip\"", urlOffset) - urlOffset) + 4 ; // 4 -> ".zip"
+	int urlOffset	= resultStr.find("\"browser_download_url\":") + searchStrSize + 1; //+ 1 to remove the extra " character
+	int urlStrSize  = (resultStr.find(".zip\"", urlOffset) - urlOffset) + 4 ; // 4 -> ".zip"
 	
-	return htmlStr.substr(urlOffset, urlStrSize);
+	return resultStr.substr(urlOffset, urlStrSize);
 }
 
 /// <summary>
-/// Download and write the file at url pFileURL onto the disk.
+/// Download and write the file from pFileURL url onto the disk.
 /// </summary>
 /// <param name="pFileURL"> : Url of the desired file.</param>
 void DownloadFile(const std::string& pFileURL)
@@ -54,8 +54,8 @@ void DownloadFile(const std::string& pFileURL)
 
 	fileStream->Stat(&streamStats, STATFLAG_DEFAULT);
 
-	DWORD byteCount;								//Out variable for windows, will not be used
-	DWORD fileSize = streamStats.cbSize.LowPart;	//Will never have to use the high part.
+	DWORD byteCount;
+	DWORD fileSize = streamStats.cbSize.LowPart;
 
 	std::vector<char> fileBuffer;
 	fileBuffer.reserve(fileSize);
@@ -64,7 +64,9 @@ void DownloadFile(const std::string& pFileURL)
 
 	fileStream->Release();
 	
-	//Get filename with PathStripPath(&wURL[0]);
+	//TODO :
+	//Get filename with :
+	//	PathStripPath(&wURL[0]);
 
 	HANDLE zipHandle = CreateFileA("./Northstar.release.v1.14.2.zip", GENERIC_WRITE, 0, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
 


### PR DESCRIPTION
### Description

Instead of using a hardcoded path and filename to download the Northstar archive, I now use GitHub API to get the latest URL and download it.